### PR TITLE
Fix manifest base path detection for GitHub Pages

### DIFF
--- a/app/ElegantDaily.tsx
+++ b/app/ElegantDaily.tsx
@@ -100,6 +100,11 @@ function stripFrontmatter(md: string = ""): string {
   return md.replace(/^---[\s\S]*?---\n?/, "");
 }
 
+function detectBase(): string {
+  if (typeof window === "undefined") return "";
+  return window.location.pathname.startsWith("/daily-site") ? "/daily-site" : "";
+}
+
 /** ---------- Component ---------- */
 export default function ElegantDaily() {
   const [manifest, setManifest] = useState<Manifest>(seedManifest);
@@ -123,12 +128,14 @@ export default function ElegantDaily() {
     let canceled = false;
     (async () => {
       try {
-        const res = await fetch(`${manifest.site?.baseUrl || ""}/manifest.json`, {
+        const base = manifest.site?.baseUrl || detectBase();
+        const res = await fetch(`${base}/manifest.json`, {
           cache: "no-store",
         });
         if (res.ok) {
           const j: Partial<Manifest> = await res.json();
-          if (!canceled) setManifest((m) => ({ ...m, ...j }));
+          if (!canceled)
+            setManifest((m) => ({ ...m, ...j, site: { ...m.site, ...j.site, baseUrl: base } }));
         }
       } catch (_e) {
         // keep seedManifest

--- a/app/game/page.tsx
+++ b/app/game/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 type Entry = { date: string; title: string; url: string; summary?: string; tags?: string[] };
 type MonthsByCategory = Record<string, Entry[]>;
@@ -19,18 +19,20 @@ function detectBase() {
 export default function GameDailyPage() {
   const [manifest, setManifest] = useState<Manifest | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const base = useMemo(() => detectBase(), []);
+  const [base, setBase] = useState('');
 
   useEffect(() => {
     // 先按环境猜测 base，去取 manifest.json
-    fetch(`${base}/manifest.json`, { cache: 'no-store' })
+    const b = detectBase();
+    setBase(b);
+    fetch(`${b}/manifest.json`, { cache: 'no-store' })
       .then(r => {
         if (!r.ok) throw new Error(`HTTP ${r.status}`);
         return r.json();
       })
       .then((data: Manifest) => setManifest(data))
       .catch((e) => setError(`读取 manifest 失败：${String(e)}`));
-  }, [base]);
+  }, []);
 
   if (error) {
     return <main className="p-6">

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,5 +1,6 @@
 // tailwind.config.ts
 import type { Config } from "tailwindcss";
+import typography from "@tailwindcss/typography";
 
 const config: Config = {
   content: [
@@ -7,7 +8,7 @@ const config: Config = {
     "./components/**/*.{js,ts,jsx,tsx,mdx}",
   ],
   theme: { extend: {} },
-  plugins: [require("@tailwindcss/typography")], // ← 开启排版插件
+  plugins: [typography], // ← 开启排版插件
 };
 
 export default config;


### PR DESCRIPTION
## Summary
- detect base path on the client to fetch manifest.json correctly
- use ESM import for Tailwind typography plugin to satisfy lint

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68becb7d1528832a97de3c038cbf8172